### PR TITLE
fix: invalid assets path

### DIFF
--- a/src/GitHubTheme.tsx
+++ b/src/GitHubTheme.tsx
@@ -10,9 +10,9 @@ export class GitHubTheme extends DefaultTheme {
 		super(renderer);
 
 		// copy the complete assets
-		renderer.on(RendererEvent.END, () => {
+		renderer.on(RendererEvent.END, (event) => {
 			const from = resolve(dirname(fileURLToPath(import.meta.url)), '../src/assets/');
-			const to = resolve(this.application.options.getValue('out'), 'assets/');
+			const to = resolve(event.outputDirectory, 'assets/');
 
 			cpSync(from, to, { recursive: true });
 		});


### PR DESCRIPTION
Assets were copied into a wrong directory if TypeDoc was configured with 'outputs' option instead of 'out'. See: https://github.com/TypeStrong/typedoc/issues/2996#issuecomment-3194100446